### PR TITLE
Replaced user validation variable from status to userRegistered

### DIFF
--- a/lint.xcodeproj/project.pbxproj
+++ b/lint.xcodeproj/project.pbxproj
@@ -175,7 +175,6 @@
 		F98FBCD625104FFB00C12527 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				F9BA2D7D2510630100E8DE75 /* LoginViewModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -192,6 +191,7 @@
 		F98FBCD82510500C00C12527 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				F9BA2D7D2510630100E8DE75 /* LoginViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";

--- a/lint/View/Login.swift
+++ b/lint/View/Login.swift
@@ -59,7 +59,7 @@ struct Login: View {
         .alert(isPresented: $viewModel.hasErrors, content: {
             Alert(title: Text("An error has occurred"), message: Text(viewModel.errorMsg), dismissButton: .destructive(Text("Dismiss")))
         })
-        .fullScreenCover(isPresented: $viewModel.status, content: {
+        .fullScreenCover(isPresented: $viewModel.userRegistered, content: {
             UserRegister()
         })
     }

--- a/lint/ViewModel/LoginViewModel.swift
+++ b/lint/ViewModel/LoginViewModel.swift
@@ -91,6 +91,7 @@ class LoginViewModel: ObservableObject {
             }
             
             self.status = true
+            self.setUserRegister(true)
             print("Success. Next step: display user's timeline.")
         }
     }


### PR DESCRIPTION
Intended to use variable `status` with a purpose (@AppStorage), but could't do it, maybe due to Xcode version.

Also moved LoginViewModel to ViewModel folder instead of Model. Didn't notice it before.